### PR TITLE
URL in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Description: Gives maximum likelihood estimation (MLE) method to
     supports covariance tapering by Furrer et al. (2006)
     <doi:10.1198/106186006X132178> to allow MLE on large data.
 License: GPL-2
+URL: https://github.com/jakobdambon/varycoef
 Depends:
     spam
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,25 +1,36 @@
-Package: varycoef
 Type: Package
+Package: varycoef
 Title: Modeling Spatially Varying Coefficients
 Version: 0.2.10
-Authors@R: c(person("Jakob", "Dambon", role = c("aut", "cre"), 
-                    email = "jakob.dambon@math.uzh.ch"), 
-             person("Fabio", "Sigrist", role = c("ctb")),
-             person("Reinhard", "Furrer", role = c("ctb")))
-Depends:
-  spam
-Imports:
-  fields, 
-  sp,
-  RandomFields
-Suggests:
-  tmap,
-  knitr,
-  rmarkdown,
-  microbenchmark
-Description: Gives maximum likelihood estimation (MLE) method to estimate and predict spatially varying coefficient (SVC) Models. It supports covariance tapering by Furrer et al. (2006) <doi:10.1198/106186006X132178> to allow MLE on large data.
+Authors@R: 
+    c(person(given = "Jakob",
+             family = "Dambon",
+             role = c("aut", "cre"),
+             email = "jakob.dambon@math.uzh.ch"),
+      person(given = "Fabio",
+             family = "Sigrist",
+             role = "ctb"),
+      person(given = "Reinhard",
+             family = "Furrer",
+             role = "ctb"))
+Description: Gives maximum likelihood estimation (MLE) method to
+    estimate and predict spatially varying coefficient (SVC) Models. It
+    supports covariance tapering by Furrer et al. (2006)
+    <doi:10.1198/106186006X132178> to allow MLE on large data.
 License: GPL-2
+Depends:
+    spam
+Imports:
+    fields,
+    RandomFields,
+    sp
+Suggests:
+    knitr,
+    microbenchmark,
+    rmarkdown,
+    tmap
+VignetteBuilder: 
+    knitr
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
-VignetteBuilder: knitr


### PR DESCRIPTION
I suggest to add the GitHub URL so when browsing on [CRAN]( https://CRAN.R-project.org/package=varycoef), the source code can be easily found. I also cleaned up the DESCRIPTION with `usethis::use_tidy_description()` so it matches a standard format.