### PR TITLE
fix: allow coercion of y in SVC_mle.formula

### DIFF
--- a/R-pkg/R/SVC_mle.R
+++ b/R-pkg/R/SVC_mle.R
@@ -720,7 +720,7 @@ SVC_mle.formula <- function(
   } else {
     W <- as.matrix(stats::model.matrix(RE_formula, data = data))
   }
-  y <- as.numeric(data[, all.vars(formula)[1]])
+  y <- as.numeric(data[, all.vars(formula)[1], drop = TRUE])
 
   # call SVC_mle with default control settings if non are provided
   if (is.null(control)) {

--- a/R-pkg/R/utils.R
+++ b/R-pkg/R/utils.R
@@ -1,13 +1,11 @@
 #' @importFrom spam cov.mat
 cov.mat32 <- function(h, theta) {
-  stopifnot(length(theta) == 2L)
   # smoothness nu = 3/2
   spam::cov.mat(h, theta = c(theta, 3/2))
 }
 
 #' @importFrom spam cov.mat
 cov.mat52 <- function(h, theta) {
-  stopifnot(length(theta) == 2L)
   # smoothness nu = 5/2
   spam::cov.mat(h, theta = c(theta, 5/2))
 }

--- a/R-pkg/R/utils.R
+++ b/R-pkg/R/utils.R
@@ -1,11 +1,13 @@
 #' @importFrom spam cov.mat
 cov.mat32 <- function(h, theta) {
+  stopifnot(length(theta) == 2L)
   # smoothness nu = 3/2
   spam::cov.mat(h, theta = c(theta, 3/2))
 }
 
 #' @importFrom spam cov.mat
 cov.mat52 <- function(h, theta) {
+  stopifnot(length(theta) == 2L)
   # smoothness nu = 5/2
   spam::cov.mat(h, theta = c(theta, 5/2))
 }


### PR DESCRIPTION
Currently, to my knowledge, `SVC_mle.formula` is not usable:

- If a matrix is passed, `stats::model.matrix` aborts because it expects a dataframe
- If a dataframe is passed, `y <- as.numeric(data[, all.vars(formula)[1]])` aborts because it expects a vector, not a one-column dataframe

This can be fixed by coercing the one-column dataframe to a vector by setting `drop = TRUE`, which is what this PR does.